### PR TITLE
fix bench tcp dial fail

### DIFF
--- a/examples/bench/bench_parallel_test.go
+++ b/examples/bench/bench_parallel_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	hproserpc "github.com/hprose/hprose-golang/rpc"
-    "strings"
 )
 
 // BenchmarkParallelHprose2 is ...
@@ -57,7 +56,7 @@ func BenchmarkParallelGobRPC(b *testing.B) {
 	b.StopTimer()
 	server := rpc.NewServer()
 	server.Register(new(Hello))
-	listener, _ := net.Listen("tcp", "")
+	listener, _ := net.Listen("tcp4", "")
 	defer listener.Close()
 	go func() {
 		for {
@@ -68,7 +67,7 @@ func BenchmarkParallelGobRPC(b *testing.B) {
 			go server.ServeConn(conn)
 		}
 	}()
-	client, _ := rpc.Dial("tcp", strings.Replace(listener.Addr().String(), "[::]", "", -1))
+	client, _ := rpc.Dial("tcp4", listener.Addr().String())
 	defer client.Close()
 	var args = &Args{"World"}
 	var reply string
@@ -115,7 +114,7 @@ func BenchmarkParallelJSONRPC(b *testing.B) {
 	b.StopTimer()
 	server := rpc.NewServer()
 	server.Register(new(Hello))
-	listener, _ := net.Listen("tcp", "")
+	listener, _ := net.Listen("tcp4", "")
 	defer listener.Close()
 	go func() {
 		for {
@@ -126,7 +125,7 @@ func BenchmarkParallelJSONRPC(b *testing.B) {
 			go server.ServeCodec(jsonrpc.NewServerCodec(conn))
 		}
 	}()
-	client, _ := jsonrpc.Dial("tcp", strings.Replace(listener.Addr().String(), "[::]", "", -1))
+	client, _ := jsonrpc.Dial("tcp4", listener.Addr().String())
 	defer client.Close()
 	var args = &Args{"World"}
 	var reply string

--- a/examples/bench/bench_parallel_test.go
+++ b/examples/bench/bench_parallel_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	hproserpc "github.com/hprose/hprose-golang/rpc"
+    "strings"
 )
 
 // BenchmarkParallelHprose2 is ...
@@ -67,7 +68,7 @@ func BenchmarkParallelGobRPC(b *testing.B) {
 			go server.ServeConn(conn)
 		}
 	}()
-	client, _ := rpc.Dial("tcp", listener.Addr().String())
+	client, _ := rpc.Dial("tcp", strings.Replace(listener.Addr().String(), "[::]", "", -1))
 	defer client.Close()
 	var args = &Args{"World"}
 	var reply string
@@ -125,7 +126,7 @@ func BenchmarkParallelJSONRPC(b *testing.B) {
 			go server.ServeCodec(jsonrpc.NewServerCodec(conn))
 		}
 	}()
-	client, _ := jsonrpc.Dial("tcp", listener.Addr().String())
+	client, _ := jsonrpc.Dial("tcp", strings.Replace(listener.Addr().String(), "[::]", "", -1))
 	defer client.Close()
 	var args = &Args{"World"}
 	var reply string

--- a/examples/bench/bench_test.go
+++ b/examples/bench/bench_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	hproserpc "github.com/hprose/hprose-golang/rpc"
+    "strings"
 )
 
 // BenchmarkHprose2 is ...
@@ -61,7 +62,7 @@ func BenchmarkGobRPC(b *testing.B) {
 			go server.ServeConn(conn)
 		}
 	}()
-	client, _ := rpc.Dial("tcp", listener.Addr().String())
+	client, _ := rpc.Dial("tcp", strings.Replace(listener.Addr().String(), "[::]", "", -1))
 	defer client.Close()
 	var args = &Args{"World"}
 	var reply string
@@ -119,7 +120,7 @@ func BenchmarkJSONRPC(b *testing.B) {
 			go server.ServeCodec(jsonrpc.NewServerCodec(conn))
 		}
 	}()
-	client, _ := jsonrpc.Dial("tcp", listener.Addr().String())
+	client, _ := jsonrpc.Dial("tcp", strings.Replace(listener.Addr().String(), "[::]", "", -1))
 	defer client.Close()
 	var args = &Args{"World"}
 	var reply string

--- a/examples/bench/bench_test.go
+++ b/examples/bench/bench_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	hproserpc "github.com/hprose/hprose-golang/rpc"
-    "strings"
 )
 
 // BenchmarkHprose2 is ...
@@ -51,7 +50,7 @@ func BenchmarkGobRPC(b *testing.B) {
 	b.StopTimer()
 	server := rpc.NewServer()
 	server.Register(new(Hello))
-	listener, _ := net.Listen("tcp", "")
+	listener, _ := net.Listen("tcp4", "")
 	defer listener.Close()
 	go func() {
 		for {
@@ -62,7 +61,7 @@ func BenchmarkGobRPC(b *testing.B) {
 			go server.ServeConn(conn)
 		}
 	}()
-	client, _ := rpc.Dial("tcp", strings.Replace(listener.Addr().String(), "[::]", "", -1))
+	client, _ := rpc.Dial("tcp4", listener.Addr().String())
 	defer client.Close()
 	var args = &Args{"World"}
 	var reply string
@@ -109,7 +108,7 @@ func BenchmarkJSONRPC(b *testing.B) {
 	b.StopTimer()
 	server := rpc.NewServer()
 	server.Register(new(Hello))
-	listener, _ := net.Listen("tcp", "")
+	listener, _ := net.Listen("tcp4", "")
 	defer listener.Close()
 	go func() {
 		for {
@@ -120,7 +119,7 @@ func BenchmarkJSONRPC(b *testing.B) {
 			go server.ServeCodec(jsonrpc.NewServerCodec(conn))
 		}
 	}()
-	client, _ := jsonrpc.Dial("tcp", strings.Replace(listener.Addr().String(), "[::]", "", -1))
+	client, _ := jsonrpc.Dial("tcp4", listener.Addr().String())
 	defer client.Close()
 	var args = &Args{"World"}
 	var reply string


### PR DESCRIPTION
在没有开启ipv6的系统跑bench test会抛出panic。
```
goroutine 5223 [running]:
net/rpc.(*Client).send(0x0, 0xc420149040)
        /home/yangxikun/Software/go/src/net/rpc/client.go:72 +0x48
net/rpc.(*Client).Go(0x0, 0xa38630, 0xb, 0x979980, 0xc42014a028, 0x98bb40, 0xc4204e0080, 0xc4203280c0, 0x1)
        /home/yangxikun/Software/go/src/net/rpc/client.go:311 +0x15d
net/rpc.(*Client).Call(0x0, 0xa38630, 0xb, 0x979980, 0xc42014a028, 0x98bb40, 0xc4204e0080, 0xc420199f68, 0x436ff8)
        /home/yangxikun/Software/go/src/net/rpc/client.go:317 +0xb1
github.com/hprose/hprose-golang/examples/bench.BenchmarkParallelJSONRPC.func2(0xc420117660)
        /home/yangxikun/Test/hprose/src/github.com/hprose/hprose-golang/examples/bench/bench_parallel_test.go:144 +0xba
testing.(*B).RunParallel.func1(0xc4204e00a0, 0xc4204e0098, 0xc4204e0090, 0xc4200cc000, 0xc420088420)
        /home/yangxikun/Software/go/src/testing/benchmark.go:605 +0x15b
created by testing.(*B).RunParallel
        /home/yangxikun/Software/go/src/testing/benchmark.go:606 +0x284
exit status 2
```
因为net.Listen默认监听了ipv6地址上的端口，而net.Dial无法连接上，导致client的值为nil。