### PR TITLE
防止误操作

### DIFF
--- a/rpc/method.go
+++ b/rpc/method.go
@@ -78,11 +78,15 @@ func (mm *methodManager) AddFunction(
 	if options.NameSpace != "" && name != "*" {
 		name = options.NameSpace + "_" + name
 	}
+	lowerName := strings.ToLower(name)
 	mm.mmLocker.Lock()
-	if mm.RemoteMethods[strings.ToLower(name)] == nil {
+	if _, ok:= mm.RemoteMethods[lowerName]; !ok {
 		mm.MethodNames = append(mm.MethodNames, name)
+		mm.RemoteMethods[lowerName] = &Method{f, options}
+	} else {
+		mm.mmLocker.Unlock()
+		panic(fmt.Sprintf("rpc method name: [%s] already exists!!", name))
 	}
-	mm.RemoteMethods[strings.ToLower(name)] = &Method{f, options}
 	mm.mmLocker.Unlock()
 }
 

--- a/rpc/method.go
+++ b/rpc/method.go
@@ -23,6 +23,7 @@ import (
 	"reflect"
 	"strings"
 	"sync"
+	"fmt"
 )
 
 // Options is the options of the published service method


### PR DESCRIPTION
还有一个建议，hprose中有大量的struct {mmLocker      sync.Mutex}写法，可以直接写为struct{sync.Mutext}简洁好看