### PR TITLE
命名空间组织

### DIFF
--- a/rpc/base_client.go
+++ b/rpc/base_client.go
@@ -565,6 +565,11 @@ func (client *BaseClient) buildRemoteService(v reflect.Value, ns string) {
 	ptr := reflect.New(et)
 	obj := ptr.Elem()
 	count := obj.NumField()
+	if ns == "" {
+		ns = strings.ToLower(et.Name())
+	} else {
+		ns += "_" + strings.ToLower(et.Name())
+	}
 	for i := 0; i < count; i++ {
 		f := obj.Field(i)
 		ft := f.Type()


### PR DESCRIPTION
解决形如这种类型的服务方法名冲突问题
type A1 struct {}
func (a *A1) Show() {
}
func B1 struct {}
func (b *B1) Show() {
}