### PR TITLE
默认使用"hprose"作为tag名，在结构体中修改字段名

### DIFF
--- a/io/struct_encoder.go
+++ b/io/struct_encoder.go
@@ -149,7 +149,7 @@ func getStructCache(structType reflect.Type) *structCache {
 	if !ok {
 		cache = &structCache{}
 		cache.Alias = structType.Name()
-		cache.Fields = getFields(structType, "")
+		cache.Fields = getFields(structType, "hprose")
 		initStructCacheData(cache)
 		structTypeCache[typ] = cache
 		structTypesLocker.Lock()


### PR DESCRIPTION
允许通过加标签的方式在结构体中修改字段名，如
```golang
type User struct {
    UserId int    `hprose:"user_id"`
    Name   string
}
```